### PR TITLE
Remove bool group from sendMessage

### DIFF
--- a/src/AsyncTelegram.h
+++ b/src/AsyncTelegram.h
@@ -112,7 +112,7 @@ public:
     //   keyboard: the inline/reply keyboard (optional)
     //             (in json format or using the inlineKeyboard/ReplyKeyboard class helper)
     
-    void sendMessage(const TBMessage &msg, const char* message, String keyboard = "", bool group = false);
+    void sendMessage(const TBMessage &msg, const char* message, String keyboard = "");
     void sendMessage(const TBMessage &msg, String &message, String keyboard = "");
     
     void sendMessage(const TBMessage &msg, const char* message, InlineKeyboard &keyboard);  


### PR DESCRIPTION
There is no needd for it. chatId will be negative for groups and positive for single chats. 
There is no special need to have a bool flag to distinguish between those.