### PR TITLE
Removed group specific functionality that make no sense

### DIFF
--- a/src/AsyncTelegram.cpp
+++ b/src/AsyncTelegram.cpp
@@ -359,7 +359,6 @@ MessageType AsyncTelegram::getNewMessage(TBMessage &message )
             message.sender.username  = root["result"][0]["message"]["from"]["username"];
             message.sender.firstName = root["result"][0]["message"]["from"]["first_name"];
             message.sender.lastName  = root["result"][0]["message"]["from"]["last_name"];
-            message.group.id         = root["result"][0]["message"]["chat"]["id"];
             message.group.title      = root["result"][0]["message"]["chat"]["title"];
             message.date             = root["result"][0]["message"]["date"];
                     
@@ -501,7 +500,7 @@ bool AsyncTelegram::getMe(TBUser &user) {
 
 
 
-void AsyncTelegram::sendMessage(const TBMessage &msg, const char* message, String keyboard, bool group)
+void AsyncTelegram::sendMessage(const TBMessage &msg, const char* message, String keyboard)
 {
     if (sizeof(message) == 0)
         return;
@@ -509,10 +508,7 @@ void AsyncTelegram::sendMessage(const TBMessage &msg, const char* message, Strin
     param.reserve(512);
     DynamicJsonDocument root(BUFFER_BIG);   
 
-    if(group)
-        root["chat_id"] = msg.group.id;
-    else
-        root["chat_id"] = msg.sender.id;
+    root["chat_id"] = msg.chatId;
     root["text"] = message;
     if (msg.isMarkdownEnabled)
         root["parse_mode"] = "Markdown";


### PR DESCRIPTION
- Removed message.group.id because there is no special uso for it.
- Removed conditional selected chatId based on if it was a group or not. Doesn't make sense. Its just a negative chatId